### PR TITLE
DEB: disable service on purge instead of removal, restart on upgrade

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -49,7 +49,7 @@ systemctl daemon-reload || true
 # Add/update state file, required for purge action in postrm
 deb-systemd-helper update-state $NAME.service || true
 
-# Only enable/start on initial install
+# Only enable on initial install
 if [ -z "$2" ]; then
   systemctl -q enable $NAME || true
   systemctl start $NAME || true

--- a/debian/postinst
+++ b/debian/postinst
@@ -46,6 +46,9 @@ fi
 
 systemctl daemon-reload || true
 
+# Add/update state file, required for purge action in postrm
+deb-systemd-helper update-state $NAME.service || true
+
 # Only enable/start on initial install
 if [ -z "$2" ]; then
   systemctl -q enable $NAME || true
@@ -57,7 +60,7 @@ else
     systemctl -q enable $NAME || true
   fi
 
-  systemctl try-restart $NAME || true
+  systemctl restart $NAME || true
 fi
 
 echo

--- a/debian/postrm
+++ b/debian/postrm
@@ -11,6 +11,9 @@ case "$1" in
     ;;
 
   purge)
+    # Disable service
+    deb-systemd-helper purge $NAME.service || true
+
     # Remove all files
     rm -rf $_ETC $_HOME $_LOG
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -5,6 +5,5 @@ NAME=fah-node
 case "$1" in
   remove)
     systemctl stop $NAME || true
-    systemctl -q disable $NAME || true
     ;;
 esac


### PR DESCRIPTION
systemctl refuses to disable inexistent units. deb-systemd-helper can do the job for us, preserving enablement state on removal.

try-restart on upgrade is problematic because if the package is removed without purge, the next install is considered an upgrade as the version is still passed as postinst's second command line argument, leading to a stopped service. Let's just restart unconditionally.